### PR TITLE
bump: version 0.1.7 → 0.1.8

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,7 +9,7 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 0.1.7
+  version: 0.1.8
   version_files:
   - cmd/root.go
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.1.8 (2025-05-31)
+
+### Fix
+
+- **devcontainer**: bump Go image version from 1.21 to 1.23
+- **deps**: bump github.com/rs/zerolog from 1.33.0 to 1.34.0
+- **deps**: bump golang.org/x/text from 0.15.0 to 0.25.0
+- **deps**: bump github.com/spf13/cobra from 1.8.0 to 1.9.1
+- **deps**: bump github.com/jedib0t/go-pretty/v6 from 6.5.9 to 6.6.7
+
 ## v0.1.7 (2024-05-27)
 
 ### Fix

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -178,7 +178,7 @@ var subnetMaskBits int
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "subnetCalc <CIDR>",
-	Version: "v0.1.7",
+	Version: "v0.1.8",
 	Short:   "calculate subnet",
 	Long: `subnetCalc is a CLI application to calculate subnets when given an IP address and a subnet mask in CIDR notation. It
 will return the requested network, host address range, broadcast address, subnet mask, maximum number of subnets, and


### PR DESCRIPTION
This pull request includes a version bump to `v0.1.8` along with updates to dependencies and the changelog. The most important changes are grouped below:

### Version Update:
* Updated the version from `v0.1.7` to `v0.1.8` in `.cz.yaml` and `cmd/root.go`. (`[[1]](diffhunk://#diff-88df54ca48a954f47ca294a53a1996dd8bfcf7cab16b4fb43ac4110bec73bda7L12-R12)`, `[[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL181-R181)`)

### Dependency and Changelog Updates:
* Added a new entry for `v0.1.8` in `CHANGELOG.md`, documenting fixes and dependency updates:
  - **devcontainer**: Updated Go image version from 1.21 to 1.23.
  - **deps**: Bumped `github.com/rs/zerolog` from 1.33.0 to 1.34.0.
  - **deps**: Bumped `golang.org/x/text` from 0.15.0 to 0.25.0.
  - **deps**: Bumped `github.com/spf13/cobra` from 1.8.0 to 1.9.1.
  - **deps**: Bumped `github.com/jedib0t/go-pretty/v6` from 6.5.9 to 6.6.7. (`[CHANGELOG.mdR1-R10](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R10)`)