### PR TITLE
bump go Go 1.25 and add unit tests

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,7 +9,7 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 0.1.10
+  version: 0.1.11
   version_files:
   - cmd/root.go
   version_scheme: semver

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Go",
-    "image": "mcr.microsoft.com/devcontainers/go:1-1.23",
+    "image": "mcr.microsoft.com/devcontainers/go:2-1.25",
     "runArgs": [
         "--userns=keep-id"
     ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set Up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00              # v6.0.0
         with:
-          go-version: '1.21'
+          go-version: '1.25'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,16 @@ repos:
     rev: 43d03392d7dc3746fa776dbddd66dfcccff70651  # frozen: v2.4.0
     hooks:
       - id: golangci-lint-full
+  - repo: local
+    hooks:
+      - id: go-test
+        name: go test
+        entry: go test ./... -v
+        language: system
+        pass_filenames: false
+        files: \.go$
+        stages:
+          - pre-commit
   - repo: https://github.com/commitizen-tools/commitizen
     rev: c710c9f541ae452547fdce5c360929f007ec4867  # frozen: v4.8.3
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.1.11 (2025-10-05)
+
+### Fix
+
+- bump Go version from 1.23 to 1.25
+- **deps**: bump golang.org/x/text from 0.28.0 to 0.29.0
+- **deps**: bump github.com/spf13/cobra from 1.9.1 to 1.10.1
+
 ## v0.1.10 (2025-08-17)
 
 ### Fix

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -182,7 +182,7 @@ var subnetMaskBits int
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "subnetCalc <CIDR>",
-	Version: "v0.1.10",
+	Version: "v0.1.11",
 	Short:   "calculate subnet",
 	Long: `subnetCalc is a CLI application to calculate subnets when given an IP address and a subnet mask in CIDR notation. It
 will return the requested network, host address range, broadcast address, subnet mask, maximum number of subnets, and

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright © 2023 Jake Rogers <code@supportoss.org>
+*/
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/netip"
+	"os"
+	"testing"
+)
+
+func TestFlipBytes(t *testing.T) {
+	tests := []struct {
+		input []byte
+		want  []byte
+	}{
+		{[]byte{0x00}, []byte{0xFF}},
+		{[]byte{0x00, 0xFF, 0xAA}, []byte{0xFF, 0x00, 0x55}},
+		{[]byte{}, []byte{}},
+		{[]byte{0xFF, 0xFF, 0xFF, 0x00}, []byte{0x00, 0x00, 0x00, 0xFF}},
+	}
+
+	for i, tt := range tests {
+		// Make a copy to avoid modifying the original slice
+		input := make([]byte, len(tt.input))
+		copy(input, tt.input)
+
+		got := flipBytes(input)
+		if !bytes.Equal(got, tt.want) {
+			t.Errorf("test %d: flipBytes(%v) = %v, want %v", i, tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestNetworkGetBroadcastAddr(t *testing.T) {
+	tests := []struct {
+		cidr string
+		want string
+	}{
+		{"192.168.1.0/24", "192.168.1.255"},
+		{"172.16.0.0/16", "172.16.255.255"},
+		{"10.0.0.0/8", "10.255.255.255"},
+		{"192.168.1.0/26", "192.168.1.63"},
+		{"192.168.1.0/30", "192.168.1.3"},
+	}
+
+	for _, tt := range tests {
+		n := getNetworkDetails(tt.cidr)
+		got := n.getBroadcastAddr()
+		want := netip.MustParseAddr(tt.want)
+
+		if got != want {
+			t.Errorf("getBroadcastAddr(%s) = %v, want %v", tt.cidr, got, want)
+		}
+	}
+}
+
+func TestNetworkGetSubnetBits(t *testing.T) {
+	tests := []struct {
+		cidr string
+		want int
+	}{
+		{"10.0.0.0/8", 0},     // Class A default
+		{"10.0.0.0/16", 8},    // Class A with subnetting
+		{"172.16.0.0/16", 0},  // Class B default
+		{"172.16.0.0/24", 8},  // Class B with subnetting
+		{"192.168.1.0/24", 0}, // Class C default
+		{"192.168.1.0/26", 2}, // Class C with subnetting
+	}
+
+	for _, tt := range tests {
+		n := getNetworkDetails(tt.cidr)
+		if got := n.getSubnetBits(); got != tt.want {
+			t.Errorf("getSubnetBits(%s) = %d, want %d", tt.cidr, got, tt.want)
+		}
+	}
+}
+
+func TestNetworkGetSubnetMask(t *testing.T) {
+	tests := []struct {
+		cidr string
+		want string
+	}{
+		{"10.0.0.0/8", "255.0.0.0"},
+		{"172.16.0.0/16", "255.255.0.0"},
+		{"192.168.1.0/24", "255.255.255.0"},
+		{"192.168.1.0/26", "255.255.255.192"},
+		{"192.168.1.0/30", "255.255.255.252"},
+		{"10.12.32.0/19", "255.255.224.0"},
+	}
+
+	for _, tt := range tests {
+		n := getNetworkDetails(tt.cidr)
+		got := n.getSubnetMask()
+		want := netip.MustParseAddr(tt.want)
+
+		if got != want {
+			t.Errorf("getSubnetMask(%s) = %v, want %v", tt.cidr, got, want)
+		}
+	}
+}
+
+func TestNetworkGetSubnets(t *testing.T) {
+	tests := []struct {
+		cidr       string
+		subnetBits int
+		wantCount  int
+	}{
+		{"192.168.1.0/24", 26, 4},  // /24 -> /26
+		{"192.168.10.0/25", 27, 4}, // /25 -> /27
+		{"10.0.0.0/16", 18, 4},     // /16 -> /18
+		{"10.12.32.0/19", 20, 2},   // /19 -> /20
+	}
+
+	for _, tt := range tests {
+		n := getNetworkDetails(tt.cidr)
+		n.getSubnets(tt.subnetBits)
+
+		if got := len(n.Subnets); got != tt.wantCount {
+			t.Errorf("getSubnets(%s, %d) created %d subnets, want %d",
+				tt.cidr, tt.subnetBits, got, tt.wantCount)
+		}
+
+		// Verify subnet properties
+		for i, subnet := range n.Subnets {
+			if subnet.MaskBits != tt.subnetBits {
+				t.Errorf("subnet[%d] has mask bits %d, want %d",
+					i, subnet.MaskBits, tt.subnetBits)
+			}
+			if !n.CIDR.Contains(subnet.NetworkAddr) {
+				t.Errorf("subnet[%d] network %v not contained in parent %v",
+					i, subnet.NetworkAddr, n.CIDR)
+			}
+		}
+	}
+}
+
+func TestGetNetworkDetails(t *testing.T) {
+	tests := []struct {
+		cidr string
+		want network
+	}{
+		{
+			cidr: "192.168.1.0/24",
+			want: network{
+				NetworkAddr:   netip.MustParseAddr("192.168.1.0"),
+				FirstHostIP:   netip.MustParseAddr("192.168.1.1"),
+				LastHostIP:    netip.MustParseAddr("192.168.1.254"),
+				BroadcastAddr: netip.MustParseAddr("192.168.1.255"),
+				SubnetMask:    netip.MustParseAddr("255.255.255.0"),
+				MaxHosts:      254,
+			},
+		},
+		{
+			cidr: "172.16.0.0/16",
+			want: network{
+				NetworkAddr:   netip.MustParseAddr("172.16.0.0"),
+				FirstHostIP:   netip.MustParseAddr("172.16.0.1"),
+				LastHostIP:    netip.MustParseAddr("172.16.255.254"),
+				BroadcastAddr: netip.MustParseAddr("172.16.255.255"),
+				SubnetMask:    netip.MustParseAddr("255.255.0.0"),
+				MaxHosts:      65534,
+			},
+		},
+		{
+			cidr: "192.168.1.0/30",
+			want: network{
+				NetworkAddr:   netip.MustParseAddr("192.168.1.0"),
+				FirstHostIP:   netip.MustParseAddr("192.168.1.1"),
+				LastHostIP:    netip.MustParseAddr("192.168.1.2"),
+				BroadcastAddr: netip.MustParseAddr("192.168.1.3"),
+				SubnetMask:    netip.MustParseAddr("255.255.255.252"),
+				MaxHosts:      2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		got := getNetworkDetails(tt.cidr)
+
+		checks := []struct {
+			name string
+			got  any
+			want any
+		}{
+			{"NetworkAddr", got.NetworkAddr, tt.want.NetworkAddr},
+			{"FirstHostIP", got.FirstHostIP, tt.want.FirstHostIP},
+			{"LastHostIP", got.LastHostIP, tt.want.LastHostIP},
+			{"BroadcastAddr", got.BroadcastAddr, tt.want.BroadcastAddr},
+			{"SubnetMask", got.SubnetMask, tt.want.SubnetMask},
+			{"MaxHosts", got.MaxHosts, tt.want.MaxHosts},
+		}
+
+		for _, check := range checks {
+			if check.got != check.want {
+				t.Errorf("getNetworkDetails(%s).%s = %v, want %v",
+					tt.cidr, check.name, check.got, check.want)
+			}
+		}
+	}
+}
+
+func TestGetNetworkDetailsInvalidInput(t *testing.T) {
+	invalidCIDRs := []string{
+		"999.999.999.999/24", // invalid IP
+		"192.168.1.0",        // missing mask
+		"192.168.1.0/99",     // invalid mask for IPv4
+		"",                   // empty string
+	}
+
+	for _, cidr := range invalidCIDRs {
+		if _, err := netip.ParsePrefix(cidr); err == nil {
+			t.Errorf("Expected error for invalid CIDR: %s", cidr)
+		}
+	}
+}
+
+func TestNetworkPrintNetworkJSON(t *testing.T) {
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	n := getNetworkDetails("192.168.1.0/24")
+	n.printNetworkJSON()
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	buf := make([]byte, 2048)
+	bytesRead, _ := r.Read(buf)
+	output := string(buf[:bytesRead])
+
+	// Verify it's valid JSON
+	var result network
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Errorf("printNetworkJSON() invalid JSON: %v\nOutput: %s", err, output)
+		return
+	}
+
+	// Verify key field
+	if result.CIDR.String() != "192.168.1.0/24" {
+		t.Errorf("JSON CIDR = %v, want 192.168.1.0/24", result.CIDR)
+	}
+}
+
+func TestIPv6Support(t *testing.T) {
+	ipv6CIDRs := []string{"2001:db8::/64", "2001:db8::/48"}
+
+	for _, cidr := range ipv6CIDRs {
+		// Test that IPv6 addresses can be parsed without crashing
+		n := getNetworkDetails(cidr)
+		if !n.CIDR.Addr().Is6() {
+			t.Errorf("Expected IPv6 address for %s", cidr)
+		}
+	}
+}
+
+// Benchmarks
+func BenchmarkGetNetworkDetails(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		getNetworkDetails("192.168.1.0/24")
+	}
+}
+
+func BenchmarkGetSubnets(b *testing.B) {
+	n := getNetworkDetails("10.0.0.0/16")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n.Subnets = nil
+		n.getSubnets(24)
+	}
+}
+
+func BenchmarkFlipBytes(b *testing.B) {
+	bytes := []byte{0xFF, 0xFF, 0xFF, 0x00}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		data := make([]byte, len(bytes))
+		copy(data, bytes)
+		flipBytes(data)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/JakeTRogers/subnetCalc
 
-go 1.24.0
+go 1.25
 
 require (
 	github.com/jedib0t/go-pretty/v6 v6.6.8

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,435 @@
+/*
+Copyright © 2023 Jake Rogers <code@supportoss.org>
+*/
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestMainIntegration tests the main CLI application end-to-end
+func TestMainIntegration(t *testing.T) {
+	// Build the binary first
+	buildCmd := exec.Command("go", "build", "-o", "subnetCalc_test", ".")
+	buildCmd.Dir = "."
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+
+	// Clean up the test binary after tests
+	defer func() {
+		_ = os.Remove("./subnetCalc_test")
+	}()
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectError    bool
+		expectedOutput []string
+		expectedRegex  []string // For pattern matching like semver
+	}{
+		{
+			name:           "Basic CIDR calculation",
+			args:           []string{"192.168.1.0/24"},
+			expectError:    false,
+			expectedOutput: []string{"Network:", "192.168.1.0/24", "Host Address Range:", "Broadcast Address:", "192.168.1.255"},
+		},
+		{
+			name:           "CIDR with subnet flag",
+			args:           []string{"192.168.1.0/24", "--subnet_size", "26"},
+			expectError:    false,
+			expectedOutput: []string{"Network:", "192.168.1.0/24", "contains", "/26", "subnets"},
+		},
+		{
+			name:           "JSON output",
+			args:           []string{"192.168.1.0/24", "--json"},
+			expectError:    false,
+			expectedOutput: []string{`"cidr"`, `"firstIP"`, `"lastIP"`, `"networkAddr"`, `"broadcastAddr"`},
+		},
+		{
+			name:        "Invalid CIDR",
+			args:        []string{"invalid.cidr"},
+			expectError: true,
+		},
+		{
+			name:           "Help command",
+			args:           []string{"--help"},
+			expectError:    false,
+			expectedOutput: []string{"Usage:", "subnetCalc", "calculate subnet"},
+		},
+		{
+			name:          "Version command",
+			args:          []string{"--version"},
+			expectError:   false,
+			expectedRegex: []string{`subnetCalc v\d+\.\d+\.\d+`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			cmd := exec.Command("./subnetCalc_test", tt.args...)
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected command to fail but it succeeded")
+				return
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("Command failed unexpectedly: %v\nStderr: %s", err, stderr.String())
+				return
+			}
+
+			output := stdout.String()
+			if stderr.Len() > 0 && !tt.expectError {
+				// For some commands, output might go to stderr (like help)
+				output += stderr.String()
+			}
+
+			// Check expected output strings
+			for _, expected := range tt.expectedOutput {
+				if !strings.Contains(output, expected) {
+					t.Errorf("Expected output to contain '%s', got:\n%s", expected, output)
+				}
+			}
+
+			// Check expected regex patterns
+			for _, pattern := range tt.expectedRegex {
+				matched, err := regexp.MatchString(pattern, output)
+				if err != nil {
+					t.Errorf("Invalid regex pattern '%s': %v", pattern, err)
+				}
+				if !matched {
+					t.Errorf("Expected output to match regex '%s', got:\n%s", pattern, output)
+				}
+			}
+		})
+	}
+}
+
+// TestJSONOutputStructure validates the JSON output structure
+func TestJSONOutputStructure(t *testing.T) {
+	// Build the binary first
+	buildCmd := exec.Command("go", "build", "-o", "subnetCalc_test", ".")
+	buildCmd.Dir = "."
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer func() { _ = os.Remove("./subnetCalc_test") }()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "Simple network JSON",
+			args: []string{"192.168.1.0/24", "--json"},
+		},
+		{
+			name: "Network with subnets JSON",
+			args: []string{"192.168.1.0/24", "--subnet_size", "26", "--json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+
+			cmd := exec.Command("./subnetCalc_test", tt.args...)
+			cmd.Stdout = &stdout
+
+			err := cmd.Run()
+			if err != nil {
+				t.Fatalf("Command failed: %v", err)
+			}
+
+			output := stdout.String()
+
+			// Parse JSON to validate structure
+			var result map[string]interface{}
+			if err := json.Unmarshal([]byte(output), &result); err != nil {
+				t.Errorf("Invalid JSON output: %v\nOutput: %s", err, output)
+				return
+			}
+
+			// Check required fields
+			requiredFields := []string{"cidr", "firstIP", "lastIP", "networkAddr", "broadcastAddr", "subnetMask", "maskBits", "maxSubnets", "maxHosts"}
+			for _, field := range requiredFields {
+				if _, exists := result[field]; !exists {
+					t.Errorf("JSON output missing required field: %s", field)
+				}
+			}
+
+			// If subnets were requested, check subnets array
+			if strings.Contains(strings.Join(tt.args, " "), "subnet_size") {
+				if subnets, exists := result["subnets"]; !exists {
+					t.Error("JSON output should contain subnets array when subnet_size is specified")
+				} else if subnetSlice, ok := subnets.([]interface{}); !ok || len(subnetSlice) == 0 {
+					t.Error("Subnets should be a non-empty array")
+				}
+			}
+		})
+	}
+}
+
+// TestErrorHandling tests various error conditions
+func TestErrorHandling(t *testing.T) {
+	// Build the binary first
+	buildCmd := exec.Command("go", "build", "-o", "subnetCalc_test", ".")
+	buildCmd.Dir = "."
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer func() { _ = os.Remove("./subnetCalc_test") }()
+
+	tests := []struct {
+		name        string
+		args        []string
+		expectError bool
+	}{
+		{
+			name:        "Invalid IP address",
+			args:        []string{"999.999.999.999/24"},
+			expectError: true,
+		},
+		{
+			name:        "Invalid CIDR format",
+			args:        []string{"192.168.1.0"},
+			expectError: true,
+		},
+		{
+			name:        "Invalid subnet mask",
+			args:        []string{"192.168.1.0/99"},
+			expectError: true,
+		},
+		{
+			name:        "Too many arguments",
+			args:        []string{"192.168.1.0/24", "extra", "args"},
+			expectError: true,
+		},
+		{
+			name:        "Subnet size smaller than network",
+			args:        []string{"192.168.1.0/24", "--subnet_size", "20"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+
+			cmd := exec.Command("./subnetCalc_test", tt.args...)
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected command to fail but it succeeded")
+			}
+
+			if !tt.expectError && err != nil {
+				t.Errorf("Command failed unexpectedly: %v\nStderr: %s", err, stderr.String())
+			}
+		})
+	}
+}
+
+// TestSubnetCalculations validates specific subnet calculation scenarios
+func TestSubnetCalculations(t *testing.T) {
+	// Build the binary first
+	buildCmd := exec.Command("go", "build", "-o", "subnetCalc_test", ".")
+	buildCmd.Dir = "."
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer func() { _ = os.Remove("./subnetCalc_test") }()
+
+	tests := []struct {
+		name           string
+		cidr           string
+		subnetSize     string
+		expectedOutput []string
+	}{
+		{
+			name:           "Split /24 into /26",
+			cidr:           "192.168.1.0/24",
+			subnetSize:     "26",
+			expectedOutput: []string{"contains 4", "/26 subnets", "192.168.1.0/26", "192.168.1.64/26", "192.168.1.128/26", "192.168.1.192/26"},
+		},
+		{
+			name:           "Split /25 into /27 (from README example)",
+			cidr:           "192.168.10.0/25",
+			subnetSize:     "27",
+			expectedOutput: []string{"contains 4", "/27 subnets", "192.168.10.0/27", "192.168.10.32/27", "192.168.10.64/27", "192.168.10.96/27"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+
+			cmd := exec.Command("./subnetCalc_test", tt.cidr, "--subnet_size", tt.subnetSize)
+			cmd.Stdout = &stdout
+
+			err := cmd.Run()
+			if err != nil {
+				t.Fatalf("Command failed: %v", err)
+			}
+
+			output := stdout.String()
+
+			for _, expected := range tt.expectedOutput {
+				if !strings.Contains(output, expected) {
+					t.Errorf("Expected output to contain '%s', got:\n%s", expected, output)
+				}
+			}
+		})
+	}
+}
+
+// TestFlags tests various flag combinations
+func TestFlags(t *testing.T) {
+	// Build the binary first
+	buildCmd := exec.Command("go", "build", "-o", "subnetCalc_test", ".")
+	buildCmd.Dir = "."
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer func() { _ = os.Remove("./subnetCalc_test") }()
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectedOutput []string
+		shouldFail     bool
+	}{
+		{
+			name:           "Color flag with subnets",
+			args:           []string{"192.168.1.0/24", "--subnet_size", "26", "--color"},
+			expectedOutput: []string{"contains 4", "/26 subnets"},
+			shouldFail:     false,
+		},
+		{
+			name:           "Verbose flag",
+			args:           []string{"192.168.1.0/24", "-v"},
+			expectedOutput: []string{"Network:", "192.168.1.0/24"},
+			shouldFail:     false,
+		},
+		{
+			name:           "Multiple verbose flags",
+			args:           []string{"192.168.1.0/24", "-vv"},
+			expectedOutput: []string{"Network:", "192.168.1.0/24"},
+			shouldFail:     false,
+		},
+		{
+			name:       "Mutually exclusive flags (color and json)",
+			args:       []string{"192.168.1.0/24", "--subnet_size", "26", "--color", "--json"},
+			shouldFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			cmd := exec.Command("./subnetCalc_test", tt.args...)
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+
+			if tt.shouldFail && err == nil {
+				t.Errorf("Expected command to fail but it succeeded")
+				return
+			}
+
+			if !tt.shouldFail && err != nil {
+				t.Errorf("Command failed unexpectedly: %v\nStderr: %s", err, stderr.String())
+				return
+			}
+
+			if !tt.shouldFail {
+				output := stdout.String()
+				for _, expected := range tt.expectedOutput {
+					if !strings.Contains(output, expected) {
+						t.Errorf("Expected output to contain '%s', got:\n%s", expected, output)
+					}
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCLIExecution benchmarks the CLI execution time
+func BenchmarkCLIExecution(b *testing.B) {
+	// Build the binary first
+	buildCmd := exec.Command("go", "build", "-o", "subnetCalc_test", ".")
+	buildCmd.Dir = "."
+	if err := buildCmd.Run(); err != nil {
+		b.Fatalf("Failed to build binary: %v", err)
+	}
+	defer func() { _ = os.Remove("./subnetCalc_test") }()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cmd := exec.Command("./subnetCalc_test", "192.168.1.0/24")
+		_ = cmd.Run()
+	}
+}
+
+// TestIPv6Handling tests IPv6 address handling (expected to be limited)
+func TestIPv6Handling(t *testing.T) {
+	// Build the binary first
+	buildCmd := exec.Command("go", "build", "-o", "subnetCalc_test", ".")
+	buildCmd.Dir = "."
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer func() { _ = os.Remove("./subnetCalc_test") }()
+
+	tests := []struct {
+		name string
+		cidr string
+	}{
+		{
+			name: "IPv6 /64",
+			cidr: "2001:db8::/64",
+		},
+		{
+			name: "IPv6 /48",
+			cidr: "2001:db8::/48",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			cmd := exec.Command("./subnetCalc_test", tt.cidr)
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+
+			// According to README, IPv6 handling is "questionable at best"
+			// So we just test that it doesn't crash completely
+			if err != nil {
+				t.Logf("IPv6 support failed as expected: %v", err)
+			} else {
+				t.Logf("IPv6 support worked for %s: %s", tt.cidr, stdout.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces several important updates to the project, including a bump to Go 1.25, dependency updates and the addition of comprehensive unit and benchmark tests. These changes improve the reliability, maintainability, and compatibility of the codebase.

**Go version and dependency updates:**

* Bumped the Go version from 1.23/1.24 to 1.25 across the development container, CI workflow, and `go.mod` for improved language features and compatibility. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R3) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L23-R23) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3)
* Updated dependencies: `golang.org/x/text` from 0.28.0 to 0.29.0 and `github.com/spf13/cobra` from 1.9.1 to 1.10.1.

**Testing improvements:**

* Added a comprehensive test suite and benchmarks in `cmd/root_test.go`, covering core subnet calculation logic, error handling, IPv6 support, and performance.